### PR TITLE
Fix duplicate GTM ID value in head.html

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,7 +14,7 @@
             dl = l != 'dataLayer' ? '&l=' + l : '';
         j.async = true;
         j.src =
-            'https://www.googletagmanager.com/gtm.js?id={{ .Site.Params.googleTagManagerID }}' + i + dl;
+            'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
         f.parentNode.insertBefore(j, f);
     })(window, document, 'script', 'dataLayer', '{{ .Site.Params.googleTagManagerID }}');
 </script>


### PR DESCRIPTION
Reported in issue #11.

[GTM docs](https://developers.google.com/tag-manager/quickstart) specify that the snippet should look like this:

```
<!-- Google Tag Manager -->
<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
})(window,document,'script','dataLayer','GTM-XXXX');</script>
<!-- End Google Tag Manager -->
```

The problem in head.html is that it is adding the GTM twice. The `dataLayer` method is how it's suggested in the snippet above, but head.html also interpolates it into the gtm.js string itself.